### PR TITLE
Django 1.8 upgrade [#91655046]

### DIFF
--- a/gargoyle/conditions.py
+++ b/gargoyle/conditions.py
@@ -315,7 +315,11 @@ class ModelConditionSet(ConditionSet):
         return '%s.%s(%s)' % (self.__module__, self.__class__.__name__, self.get_namespace())
 
     def get_namespace(self):
-        return '%s.%s' % (self.model._meta.app_label, self.model._meta.module_name)
+        if hasattr(self.model._meta, 'model_name'):
+            model_name = self.model._meta.model_name
+        else:
+            model_name = self.model._meta.module_name
+        return '%s.%s' % (self.model._meta.app_label, model_name)
 
     def get_group_label(self):
         return self.model._meta.verbose_name.title()


### PR DESCRIPTION
_WORK IN PROGRESS_
- Use `model_name` in favour of `module_name` if available (backport [PR 95 from disqus/gargoyle](https://github.com/disqus/gargoyle/pull/95))
